### PR TITLE
Queue based architecture

### DIFF
--- a/bartering-test/node1/node1.go
+++ b/bartering-test/node1/node1.go
@@ -50,11 +50,16 @@ func main() {
 
 	var wg sync.WaitGroup
 
+	// Message queue
+	storageRequestsChannel := make(chan datastructures.StorageRequestQueueMessage)
+	// newFilesChannel := make(chan datastructures.StorageRequest)
+	testRequestsChannel := make(chan datastructures.TestRequestQueueMessage)
+
 	wg.Add(1)
 	deletionQueue := []datastructures.StorageRequestTimedAccepted{}
 	go func() {
 		defer wg.Done()
-		peersconnect.ListenPeersRequestsTCP(PORT, NodeStorage, bytesAtPeers, scores, ratiosAtPeers, ratiosForPeers, bytesForPeers, &storedForPeers, config.BarteringFactorAcceptableRatio, &deletionQueue, &msgCounter)
+		peersconnect.ListenPeersRequestsTCP(PORT, NodeStorage, bytesAtPeers, scores, ratiosAtPeers, ratiosForPeers, bytesForPeers, &storedForPeers, config.BarteringFactorAcceptableRatio, &deletionQueue, &msgCounter, storageRequestsChannel, testRequestsChannel)
 	}()
 
 	err := bartering.InitiateBarter("127.0.0.1", ratiosAtPeers, config.BarteringRatioIncreaseRate, PORT, &msgCounter)

--- a/bartering-test/node2/node2.go
+++ b/bartering-test/node2/node2.go
@@ -49,9 +49,14 @@ func main() {
 	deletionQueue := []datastructures.StorageRequestTimedAccepted{}
 	wg.Add(1)
 
+	// Message queue
+	storageRequestsChannel := make(chan datastructures.StorageRequestQueueMessage)
+	// newFilesChannel := make(chan datastructures.StorageRequest)
+	testRequestsChannel := make(chan datastructures.TestRequestQueueMessage)
+
 	go func() {
 		defer wg.Done()
-		peersconnect.ListenPeersRequestsTCP(PORT, NodeStorage, bytesAtPeers, scores, ratiosAtPeers, ratiosForPeers, bytesForPeers, &storedForPeers, config.BarteringFactorAcceptableRatio, &deletionQueue, &msgCounter)
+		peersconnect.ListenPeersRequestsTCP(PORT, NodeStorage, bytesAtPeers, scores, ratiosAtPeers, ratiosForPeers, bytesForPeers, &storedForPeers, config.BarteringFactorAcceptableRatio, &deletionQueue, &msgCounter, storageRequestsChannel, testRequestsChannel)
 	}()
 
 	wg.Wait()

--- a/data-structures/data-structures.go
+++ b/data-structures/data-structures.go
@@ -1,6 +1,9 @@
 package datastructures
 
-import "time"
+import (
+	"net"
+	"time"
+)
 
 type NodeScore struct {
 	NodeIP string
@@ -46,4 +49,14 @@ type FilesAtPeers struct {
 type ScoreVariationScenario struct {
 	Scenario  string
 	Variation float64
+}
+
+type StorageRequestQueueMessage struct {
+	StorageRequest StorageRequest
+	Conn           net.Conn
+}
+
+type TestRequestQueueMessage struct {
+	CID  string
+	Conn net.Conn
 }

--- a/failure-simulation-test/node.go
+++ b/failure-simulation-test/node.go
@@ -49,13 +49,18 @@ func main() {
 
 	var failureMutex sync.Mutex
 
+	// Message queue
+	storageRequestsChannel := make(chan datastructures.StorageRequestQueueMessage)
+	// newFilesChannel := make(chan datastructures.StorageRequest)
+	testRequestsChannel := make(chan datastructures.TestRequestQueueMessage)
+
 	go failuresimulation.Failure(config, 2.0, 100, &failureMutex)
 
 	wg.Add(1)
 	deletionQueue := []datastructures.StorageRequestTimedAccepted{}
 	go func() {
 		defer wg.Done()
-		peersconnect.ListenPeersRequestsTCPFailure(port, NodeStorage, bytesAtPeers, scores, ratiosAtPeers, ratiosForPeers, bytesForPeers, &storedForPeers, config.BarteringFactorAcceptableRatio, &deletionQueue, &failureMutex, &msgCounter)
+		peersconnect.ListenPeersRequestsTCPFailure(port, NodeStorage, bytesAtPeers, scores, ratiosAtPeers, ratiosForPeers, bytesForPeers, &storedForPeers, config.BarteringFactorAcceptableRatio, &deletionQueue, &failureMutex, &msgCounter, storageRequestsChannel, testRequestsChannel)
 	}()
 
 	// to_request, err := storagerequests.ElectStorageNodes(scores, 3)

--- a/fs-watcher/fs-watcher.go
+++ b/fs-watcher/fs-watcher.go
@@ -5,7 +5,7 @@ import (
 	datastructures "bartering/data-structures"
 
 	// "bartering/functions"
-	storagerequests "bartering/storage-requests"
+
 	"fmt"
 	"log"
 
@@ -19,7 +19,7 @@ func getFileSize(path string) int64 {
 	return fileInfo.Size()
 }
 
-func FsWatcher(path string, peerScores []datastructures.NodeScore, K int, port string, bytesAtPeers []datastructures.PeerStorageUse, fulfilledRequests *[]datastructures.FulfilledRequest, scoreDecreaseRefStoReq float64) {
+func FsWatcher(path string, peerScores []datastructures.NodeScore, K int, port string, bytesAtPeers []datastructures.PeerStorageUse, fulfilledRequests *[]datastructures.FulfilledRequest, scoreDecreaseRefStoReq float64, newFileChannel chan datastructures.StorageRequest) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Fatal(err)
@@ -46,7 +46,8 @@ func FsWatcher(path string, peerScores []datastructures.NodeScore, K int, port s
 					} else {
 						fmt.Println("File uploaded ", filePath, " uploaded to IPFS ; requesting storage from peer now")
 						storageRequest := datastructures.StorageRequest{CID: CID, FileSize: float64(getFileSize(filePath))}
-						go storagerequests.StoreKCopiesOnNetwork(peerScores, K, storageRequest, port, bytesAtPeers, fulfilledRequests, scoreDecreaseRefStoReq)
+						// go storagerequests.StoreKCopiesOnNetwork(peerScores, K, storageRequest, port, bytesAtPeers, fulfilledRequests, scoreDecreaseRefStoReq)
+						newFileChannel <- storageRequest
 					}
 				}
 				if event.Op&fsnotify.Write == fsnotify.Write {

--- a/main-test/node1/node1.go
+++ b/main-test/node1/node1.go
@@ -55,12 +55,17 @@ func main() {
 
 	var wg sync.WaitGroup // Import "sync" package to use WaitGroup.
 
+	// Message queue
+	storageRequestsChannel := make(chan datastructures.StorageRequestQueueMessage)
+	newFilesChannel := make(chan datastructures.StorageRequest)
+	testRequestsChannel := make(chan datastructures.TestRequestQueueMessage)
+
 	wg.Add(1)
 	deletionQueue := []datastructures.StorageRequestTimedAccepted{}
 	go func() {
 		// PEER LISTENER - to receive messages from other peers
 		defer wg.Done()
-		peersconnect.ListenPeersRequestsTCP(port, NodeStorage, bytesAtPeers, scores, ratiosAtPeers, ratiosForPeers, bytesForPeers, &storedForPeers, config.BarteringFactorAcceptableRatio, &deletionQueue, &msgCounter)
+		peersconnect.ListenPeersRequestsTCP(port, NodeStorage, bytesAtPeers, scores, ratiosAtPeers, ratiosForPeers, bytesForPeers, &storedForPeers, config.BarteringFactorAcceptableRatio, &deletionQueue, &msgCounter, storageRequestsChannel, testRequestsChannel)
 	}()
 
 	wg.Add(1)
@@ -74,7 +79,7 @@ func main() {
 	go func() {
 		// FSWATCHER - to upload data on network
 		defer wg.Done()
-		fswatcher.FsWatcher("./data", scores, config.DataCopies, port, bytesAtPeers, &fulfilled_requests, config.StoragerequestsScoreDecreaseRefusedStoReq)
+		fswatcher.FsWatcher("./data", scores, config.DataCopies, port, bytesAtPeers, &fulfilled_requests, config.StoragerequestsScoreDecreaseRefusedStoReq, newFilesChannel)
 	}()
 
 	// TODO : BARTERER, FAILURESIM, DATASIM

--- a/main-test/node2/node2.go
+++ b/main-test/node2/node2.go
@@ -46,11 +46,15 @@ func main() {
 
 	var wg sync.WaitGroup // Import "sync" package to use WaitGroup.
 
+	// Message queue
+	storageRequestsChannel := make(chan datastructures.StorageRequestQueueMessage)
+	testRequestChannel := make(chan datastructures.TestRequestQueueMessage)
+
 	wg.Add(1)
 	deletionQueue := []datastructures.StorageRequestTimedAccepted{}
 	go func() {
 		defer wg.Done()
-		peersconnect.ListenPeersRequestsTCP(port, NodeStorage, bytesAtPeers, scores, ratiosAtPeers, ratiosForPeers, bytesForPeers, &storedForPeers, config.BarteringFactorAcceptableRatio, &deletionQueue, &msgCounter)
+		peersconnect.ListenPeersRequestsTCP(port, NodeStorage, bytesAtPeers, scores, ratiosAtPeers, ratiosForPeers, bytesForPeers, &storedForPeers, config.BarteringFactorAcceptableRatio, &deletionQueue, &msgCounter, storageRequestsChannel, testRequestChannel)
 	}()
 
 	// Wait for the goroutine to finish.

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	fswatcher "bartering/fs-watcher"
 	"bartering/functions"
 	peersconnect "bartering/peers-connect"
+	storagerequests "bartering/storage-requests"
 	storagetesting "bartering/storage-testing"
 )
 
@@ -28,7 +29,7 @@ func main() {
 
 	config := configextractor.ConfigExtractor("config.yaml")
 
-	port := fmt.Sprint(config.Port)
+	port := "8081"
 	NodeStorage := config.TotalStorage
 
 	configextractor.ConfigPrinter(config)
@@ -51,12 +52,24 @@ func main() {
 
 	var wg sync.WaitGroup
 
+	// Message queues
+	storageRequestsChannel := make(chan datastructures.StorageRequestQueueMessage)
+	newFilesChannel := make(chan datastructures.StorageRequest)
+	testRequestsChannel := make(chan datastructures.TestRequestQueueMessage)
+
 	wg.Add(1)
 	deletionQueue := []datastructures.StorageRequestTimedAccepted{}
 	go func() {
 		// PEER LISTENER - to receive messages from other peers
 		defer wg.Done()
-		peersconnect.ListenPeersRequestsTCP(port, NodeStorage, bytesAtPeers, scores, ratiosAtPeers, ratiosForPeers, bytesForPeers, &storedForPeers, config.BarteringFactorAcceptableRatio, &deletionQueue, &msgCounter)
+		peersconnect.ListenPeersRequestsTCP(port, NodeStorage, bytesAtPeers, scores, ratiosAtPeers, ratiosForPeers, bytesForPeers, &storedForPeers, config.BarteringFactorAcceptableRatio, &deletionQueue, &msgCounter, storageRequestsChannel, testRequestsChannel)
+	}()
+
+	wg.Add(1)
+	go func() {
+		// Handle storage requests pool
+		defer wg.Done()
+		storagerequests.HandleStorageRequest(bytesForPeers, &storedForPeers, storageRequestsChannel)
 	}()
 
 	wg.Add(1)
@@ -65,12 +78,26 @@ func main() {
 		defer wg.Done()
 		storagetesting.PeriodicTests(&fulfilled_requests, scores, config.StoragetestingTimerTimeoutSec, port, config.StoragetestingTestingPeriod, DecreaseBehavior, IncreaseBehavior, bytesAtPeers, config.StoragerequestsScoreDecreaseRefusedStoReq)
 	}()
-	fmt.Println("Main; peers :", scores)
+
+	wg.Add(1)
+	go func() {
+		// Handle new files pool
+		defer wg.Done()
+		storagerequests.StoreKCopiesOnNetwork(scores, 2, port, bytesAtPeers, &fulfilled_requests, config.StoragerequestsScoreDecreaseRefusedStoReq, newFilesChannel)
+	}()
+
 	wg.Add(1)
 	go func() {
 		// FSWATCHER - to upload data on network
 		defer wg.Done()
-		fswatcher.FsWatcher("./data", scores, config.DataCopies, port, bytesAtPeers, &fulfilled_requests, config.StoragerequestsScoreDecreaseRefusedStoReq)
+		fswatcher.FsWatcher("./data", scores, config.DataCopies, port, bytesAtPeers, &fulfilled_requests, config.StoragerequestsScoreDecreaseRefusedStoReq, newFilesChannel)
+	}()
+
+	wg.Add(1)
+	go func() {
+		// Test Handler pool
+		defer wg.Done()
+		storagetesting.HandleTest(testRequestsChannel)
 	}()
 
 	fmt.Println("Node started ! Listening on port ", port)

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 
 	config := configextractor.ConfigExtractor("config.yaml")
 
-	port := "8081"
+	port := fmt.Sprint(config.Port)
 	NodeStorage := config.TotalStorage
 
 	configextractor.ConfigPrinter(config)

--- a/peers-connect/peers-connect.go
+++ b/peers-connect/peers-connect.go
@@ -3,16 +3,16 @@ package peersconnect
 import (
 	"fmt"
 	"net"
+	"strconv"
+	"strings"
 	"sync"
 
 	"bartering/bartering-api"
 	datastructures "bartering/data-structures"
-	storagerequests "bartering/storage-requests"
-	storagetesting "bartering/storage-testing"
 	"bartering/utils"
 )
 
-func ListenPeersRequestsTCPFailure(port string, nodeStorage float64, bytesAtPeers []datastructures.PeerStorageUse, scores []datastructures.NodeScore, ratiosAtPeers []datastructures.NodeRatio, ratiosForPeers []datastructures.NodeRatio, bytesForPeers []datastructures.PeerStorageUse, storedForPeers *[]datastructures.FulfilledRequest, factorAcceptableRatio float64, deletienQueue *[]datastructures.StorageRequestTimedAccepted, failureMutex *sync.Mutex, msgCounter *int) {
+func ListenPeersRequestsTCPFailure(port string, nodeStorage float64, bytesAtPeers []datastructures.PeerStorageUse, scores []datastructures.NodeScore, ratiosAtPeers []datastructures.NodeRatio, ratiosForPeers []datastructures.NodeRatio, bytesForPeers []datastructures.PeerStorageUse, storedForPeers *[]datastructures.FulfilledRequest, factorAcceptableRatio float64, deletienQueue *[]datastructures.StorageRequestTimedAccepted, failureMutex *sync.Mutex, msgCounter *int, storageRequestChannel chan datastructures.StorageRequestQueueMessage, testRequestsChannel chan datastructures.TestRequestQueueMessage) {
 
 	/*
 		TCP server to receive messages from peers
@@ -29,12 +29,12 @@ func ListenPeersRequestsTCPFailure(port string, nodeStorage float64, bytesAtPeer
 	for {
 		failureMutex.Lock()
 		conn, _ := listener.Accept()
-		go handleConnection(conn, nodeStorage, bytesAtPeers, scores, ratiosAtPeers, bytesForPeers, storedForPeers, factorAcceptableRatio, deletienQueue, msgCounter)
+		go handleConnection(conn, nodeStorage, bytesAtPeers, scores, ratiosAtPeers, bytesForPeers, storedForPeers, factorAcceptableRatio, deletienQueue, msgCounter, storageRequestChannel, testRequestsChannel)
 		failureMutex.Unlock()
 	}
 }
 
-func ListenPeersRequestsTCP(port string, nodeStorage float64, bytesAtPeers []datastructures.PeerStorageUse, scores []datastructures.NodeScore, ratiosAtPeers []datastructures.NodeRatio, ratiosForPeers []datastructures.NodeRatio, bytesForPeers []datastructures.PeerStorageUse, storedForPeers *[]datastructures.FulfilledRequest, factorAcceptableRatio float64, deletienQueue *[]datastructures.StorageRequestTimedAccepted, msgCounter *int) {
+func ListenPeersRequestsTCP(port string, nodeStorage float64, bytesAtPeers []datastructures.PeerStorageUse, scores []datastructures.NodeScore, ratiosAtPeers []datastructures.NodeRatio, ratiosForPeers []datastructures.NodeRatio, bytesForPeers []datastructures.PeerStorageUse, storedForPeers *[]datastructures.FulfilledRequest, factorAcceptableRatio float64, deletienQueue *[]datastructures.StorageRequestTimedAccepted, msgCounter *int, storageRequestsChannel chan datastructures.StorageRequestQueueMessage, testRequestsChannel chan datastructures.TestRequestQueueMessage) {
 
 	/*
 		TCP server to receive messages from peers
@@ -47,11 +47,11 @@ func ListenPeersRequestsTCP(port string, nodeStorage float64, bytesAtPeers []dat
 	defer listener.Close()
 	for {
 		conn, _ := listener.Accept()
-		go handleConnection(conn, nodeStorage, bytesAtPeers, scores, ratiosAtPeers, bytesForPeers, storedForPeers, factorAcceptableRatio, deletienQueue, msgCounter)
+		go handleConnection(conn, nodeStorage, bytesAtPeers, scores, ratiosAtPeers, bytesForPeers, storedForPeers, factorAcceptableRatio, deletienQueue, msgCounter, storageRequestsChannel, testRequestsChannel)
 	}
 }
 
-func handleConnection(conn net.Conn, nodeStorage float64, bytesAtPeers []datastructures.PeerStorageUse, scores []datastructures.NodeScore, ratios []datastructures.NodeRatio, bytesForPeers []datastructures.PeerStorageUse, storedForPeers *[]datastructures.FulfilledRequest, factorAcceptableRatio float64, deletionQueue *[]datastructures.StorageRequestTimedAccepted, msgCounter *int) {
+func handleConnection(conn net.Conn, nodeStorage float64, bytesAtPeers []datastructures.PeerStorageUse, scores []datastructures.NodeScore, ratios []datastructures.NodeRatio, bytesForPeers []datastructures.PeerStorageUse, storedForPeers *[]datastructures.FulfilledRequest, factorAcceptableRatio float64, deletionQueue *[]datastructures.StorageRequestTimedAccepted, msgCounter *int, storageRequestsChannel chan datastructures.StorageRequestQueueMessage, testRequestsChannel chan datastructures.TestRequestQueueMessage) {
 
 	/*
 		Connection handler for TCP connections received through the TCP server
@@ -63,10 +63,10 @@ func handleConnection(conn net.Conn, nodeStorage float64, bytesAtPeers []datastr
 	buffer := make([]byte, 63)
 
 	conn.Read(buffer)
-	MessageDiscriminator(buffer, conn, nodeStorage, bytesAtPeers, scores, ratios, bytesForPeers, storedForPeers, factorAcceptableRatio, deletionQueue, msgCounter)
+	MessageDiscriminator(buffer, conn, nodeStorage, bytesAtPeers, scores, ratios, bytesForPeers, storedForPeers, factorAcceptableRatio, deletionQueue, msgCounter, storageRequestsChannel, testRequestsChannel)
 }
 
-func MessageDiscriminator(buffer []byte, conn net.Conn, nodeStorage float64, bytesAtPeers []datastructures.PeerStorageUse, scores []datastructures.NodeScore, ratios []datastructures.NodeRatio, bytesForPeers []datastructures.PeerStorageUse, storedForPeers *[]datastructures.FulfilledRequest, factorAcceptableRatio float64, deletionQueue *[]datastructures.StorageRequestTimedAccepted, msgCounter *int) {
+func MessageDiscriminator(buffer []byte, conn net.Conn, nodeStorage float64, bytesAtPeers []datastructures.PeerStorageUse, scores []datastructures.NodeScore, ratios []datastructures.NodeRatio, bytesForPeers []datastructures.PeerStorageUse, storedForPeers *[]datastructures.FulfilledRequest, factorAcceptableRatio float64, deletionQueue *[]datastructures.StorageRequestTimedAccepted, msgCounter *int, storageRequestsChannel chan datastructures.StorageRequestQueueMessage, testRequestsChannel chan datastructures.TestRequestQueueMessage) {
 
 	/*
 		Function used to discriminate different types of messages and call the necessary functions for each type of messages
@@ -78,7 +78,12 @@ func MessageDiscriminator(buffer []byte, conn net.Conn, nodeStorage float64, byt
 
 	if messageType == "StoRq" {
 		fmt.Println("Received storage request")
-		storagerequests.HandleStorageRequest(bufferString, conn, bytesForPeers, storedForPeers)
+		// storagerequests.HandleStorageRequest(bufferString, conn, bytesForPeers, storedForPeers)
+		storageRequest, err := buildStorageRequest(bufferString)
+		queueMessage := datastructures.StorageRequestQueueMessage{StorageRequest: storageRequest, Conn: conn}
+		if err == nil {
+			storageRequestsChannel <- queueMessage
+		}
 	} else if messageType == "BarRq" {
 		remoteAddr := conn.RemoteAddr()
 		ip, _, err := net.SplitHostPort(remoteAddr.String())
@@ -88,8 +93,26 @@ func MessageDiscriminator(buffer []byte, conn net.Conn, nodeStorage float64, byt
 	} else if messageType == "TesRq" {
 		CID := bufferString[5 : len(bufferString)-1]
 		fmt.Println("Recieved test request for file ", CID)
-		storagetesting.HandleTest(CID, conn)
+		testRequest := datastructures.TestRequestQueueMessage{CID: CID, Conn: conn}
+		// storagetesting.HandleTest(CID, conn)
+		testRequestsChannel <- testRequest
 	} else {
 		fmt.Println("Unrecognized message : ", bufferString)
 	}
+}
+
+func buildStorageRequest(bufferString string) (datastructures.StorageRequest, error) {
+
+	CID := bufferString[5:51]
+
+	fileSize := bufferString[51:]
+	fileSize = strings.Split(fileSize, "\n")[0]
+	fileSizeFloat, err := strconv.ParseFloat(fileSize, 64)
+
+	if err != nil {
+		return datastructures.StorageRequest{}, fmt.Errorf("could not parse file size ; storage request invalid")
+	}
+
+	return datastructures.StorageRequest{FileSize: fileSizeFloat, CID: CID}, nil
+
 }

--- a/storage-requests-test/node1/node1.go
+++ b/storage-requests-test/node1/node1.go
@@ -46,11 +46,15 @@ func main() {
 
 	var wg sync.WaitGroup // Import "sync" package to use WaitGroup.
 
+	// Message queue
+	storageRequestsChannel := make(chan datastructures.StorageRequestQueueMessage)
+	testRequestChannel := make(chan datastructures.TestRequestQueueMessage)
+
 	wg.Add(1)
 	deletionQueue := []datastructures.StorageRequestTimedAccepted{}
 	go func() {
 		defer wg.Done()
-		peersconnect.ListenPeersRequestsTCP(port, NodeStorage, bytesAtPeers, scores, ratiosAtPeers, ratiosForPeers, bytesForPeers, &storedForPeers, config.BarteringFactorAcceptableRatio, &deletionQueue, &msgCounter)
+		peersconnect.ListenPeersRequestsTCP(port, NodeStorage, bytesAtPeers, scores, ratiosAtPeers, ratiosForPeers, bytesForPeers, &storedForPeers, config.BarteringFactorAcceptableRatio, &deletionQueue, &msgCounter, storageRequestsChannel, testRequestChannel)
 	}()
 
 	// stoRq := datastructures.StorageRequest{CID: "QmV9tSDx9UiPeWExXEeH6aoDvmihvx6jD5eLb4jbTaKGps", FileSize: 5.0}

--- a/storage-requests-test/node2/node2.go
+++ b/storage-requests-test/node2/node2.go
@@ -50,11 +50,15 @@ func main() {
 
 	var wg sync.WaitGroup // Import "sync" package to use WaitGroup.
 
+	// Message queue
+	storageRequestsChannel := make(chan datastructures.StorageRequestQueueMessage)
+	testRequestsChannel := make(chan datastructures.TestRequestQueueMessage)
+
 	wg.Add(1)
 
 	go func() {
 		defer wg.Done()
-		peersconnect.ListenPeersRequestsTCP(port, NodeStorage, bytesAtPeers, scores, ratiosAtPeers, ratiosForPeers, bytesForPeers, &storedForPeers, config.BarteringFactorAcceptableRatio, &deletionQueue, &msgCounter)
+		peersconnect.ListenPeersRequestsTCP(port, NodeStorage, bytesAtPeers, scores, ratiosAtPeers, ratiosForPeers, bytesForPeers, &storedForPeers, config.BarteringFactorAcceptableRatio, &deletionQueue, &msgCounter, storageRequestsChannel, testRequestsChannel)
 	}()
 
 	// Wait for the goroutine to finish.

--- a/storage-requests/storage-requests.go
+++ b/storage-requests/storage-requests.go
@@ -14,39 +14,37 @@ import (
 	"time"
 )
 
-func StoreKCopiesOnNetwork(peerScores []datastructures.NodeScore, K int, storageRequest datastructures.StorageRequest, port string, bytesAtPeers []datastructures.PeerStorageUse, fulfilledRequests *[]datastructures.FulfilledRequest, scoreDecreaseRefStoReq float64) int {
+func StoreKCopiesOnNetwork(peerScores []datastructures.NodeScore, K int, port string, bytesAtPeers []datastructures.PeerStorageUse, fulfilledRequests *[]datastructures.FulfilledRequest, scoreDecreaseRefStoReq float64, newFileChannel chan datastructures.StorageRequest) {
 	okRqs := 0
 	ans := ""
 	tries := 0
 
-	for tries < 3 {
-		peersToRequest, err := ElectStorageNodes(peerScores, K)
-		if err != nil {
-			fmt.Println(err)
-			return 0
-		}
+	for request := range newFileChannel {
 
-		for _, peer := range peersToRequest {
-			ans = RequestStorageFromPeer(peer, storageRequest, port, bytesAtPeers, peerScores, fulfilledRequests, scoreDecreaseRefStoReq)
-			if ans == "OK\n" {
-				okRqs += 1
-				peerScores = RemovePeerFromPeers(peerScores, peer)
-			} else if ans == "ERR" {
-				fmt.Println("Skipping as connection refused by peer ", peer)
+		for tries < 3 {
+			peersToRequest, err := ElectStorageNodes(peerScores, K)
+			if err != nil {
+				fmt.Println(err)
 			}
-			if okRqs == K {
-				fmt.Println("Reached required number of copies")
-				return okRqs
+
+			for _, peer := range peersToRequest {
+				ans = RequestStorageFromPeer(peer, request, port, bytesAtPeers, peerScores, fulfilledRequests, scoreDecreaseRefStoReq)
+				if ans == "OK\n" {
+					okRqs += 1
+					peerScores = RemovePeerFromPeers(peerScores, peer)
+				} else if ans == "ERR" {
+					fmt.Println("Skipping as connection refused by peer ", peer)
+				}
+				if okRqs == K {
+					fmt.Println("Reached required number of copies")
+				}
 			}
+			fmt.Println("Could not reach number of copies ... choosing new nodes")
+			tries += 1
 		}
-		fmt.Println("Could not reach number of copies ... choosing new nodes")
-		tries += 1
+		newFileChannel <- request
+		fmt.Println("Could not reach desired number of copies -  only got ", okRqs)
 	}
-
-	fmt.Println("Could not reach desired number of copies -  only got ", okRqs)
-
-	return okRqs
-
 }
 
 func RemovePeerFromPeers(peerScores []datastructures.NodeScore, peerToRm string) []datastructures.NodeScore {
@@ -193,52 +191,42 @@ func updateBytesForPeers(bytesForPeers []datastructures.PeerStorageUse, peer str
 	}
 }
 
-func HandleStorageRequest(bufferString string, conn net.Conn, bytesForPeers []datastructures.PeerStorageUse, storedForPeers *[]datastructures.FulfilledRequest) {
+func HandleStorageRequest(bytesForPeers []datastructures.PeerStorageUse, storedForPeers *[]datastructures.FulfilledRequest, storageRequestsChannel chan datastructures.StorageRequestQueueMessage) {
 
 	/*
 		Function to handle a storage message type message
 		Arguments : buffer received through a tcp connection, as a string, net.Conn object, PeerStorageUse array, pointer to fulfilledRequest array
 	*/
-
-	peer := conn.RemoteAddr().(*net.TCPAddr).IP.String()
 	var messageToPeer string
-	fmt.Println("Received storage request")
-	CID := bufferString[5:51]
-	fmt.Println("CID : ", CID)
-	fileSize := bufferString[51:]
-	fileSize = strings.Split(fileSize, "\n")[0]
-	fmt.Println("File Size : ", fileSize)
 
-	fileSizeFloat, err := strconv.ParseFloat(fileSize, 64)
-	utils.ErrorHandler(err)
+	for requestMessage := range storageRequestsChannel {
+		request, conn := requestMessage.StorageRequest, requestMessage.Conn
+		peer := conn.RemoteAddr().String()
 
-	request := datastructures.StorageRequest{FileSize: fileSizeFloat, CID: CID}
+		fmt.Println("Storage request : ", request, " ; checking validity ...")
 
-	fmt.Println("Storage request : ", request, " ; checking validity ...")
+		if CheckRqValidity(request) {
+			fmt.Println("Request ", request, " valid, storing ! ")
+			fmt.Println("Pinning to IPFS ...")
+			_, err := api_ipfs.PinToIPFS(request.CID)
+			if err == nil {
+				fmt.Println("File pinned to IPFS!")
+				messageToPeer = "OK\n"
+				updateBytesForPeers(bytesForPeers, peer, request.FileSize)
+				updateFulfilledRequests(request.CID, peer, storedForPeers)
+				fmt.Println("stored for peers : ", storedForPeers)
+			} else {
+				fmt.Println("could not pin to ipfs - is ipfs running ?")
+			}
 
-	if CheckRqValidity(request) {
-		fmt.Println("Request ", request, " valid, storing ! ")
-		fmt.Println("Pinning to IPFS ...")
-		_, err := api_ipfs.PinToIPFS(CID)
-		if err == nil {
-			fmt.Println("File pinned to IPFS!")
-			messageToPeer = "OK\n"
-			updateBytesForPeers(bytesForPeers, peer, fileSizeFloat)
-			updateFulfilledRequests(CID, peer, storedForPeers)
-			fmt.Println("stored for peers : ", storedForPeers)
 		} else {
-			fmt.Println("could not pin to ipfs - is ipfs running ?")
+			fmt.Println("Request ", request, " not valid, not storing ! ")
+
+			messageToPeer = "KO\n"
 		}
 
-	} else {
-		fmt.Println("Request ", request, " not valid, not storing ! ")
-
-		messageToPeer = "KO\n"
+		_, _ = io.WriteString(conn, messageToPeer)
 	}
-
-	_, err = io.WriteString(conn, messageToPeer)
-
-	utils.ErrorHandler(err)
 
 }
 

--- a/storage-testing-test/node1/node1.go
+++ b/storage-testing-test/node1/node1.go
@@ -55,9 +55,13 @@ func main() {
 
 	deletionQueue := []datastructures.StorageRequestTimedAccepted{}
 
+	// Message queue
+	storageRequestsChannel := make(chan datastructures.StorageRequestQueueMessage)
+	testRequestsChannel := make(chan datastructures.TestRequestQueueMessage)
+
 	go func() {
 		defer wg.Done()
-		peersconnect.ListenPeersRequestsTCP(port, NodeStorage, bytesAtPeers, scores, ratiosAtPeers, ratiosForPeers, bytesForPeers, &storedForPeers, config.BarteringFactorAcceptableRatio, &deletionQueue, &msgCounter)
+		peersconnect.ListenPeersRequestsTCP(port, NodeStorage, bytesAtPeers, scores, ratiosAtPeers, ratiosForPeers, bytesForPeers, &storedForPeers, config.BarteringFactorAcceptableRatio, &deletionQueue, &msgCounter, storageRequestsChannel, testRequestsChannel)
 	}()
 
 	storage_request := datastructures.StorageRequest{CID: "QmV9tSDx9UiPeWExXEeH6aoDvmihvx6jD5eLb4jbTaKGps", FileSize: 5.5}

--- a/storage-testing-test/node2/node2.go
+++ b/storage-testing-test/node2/node2.go
@@ -48,9 +48,13 @@ func main() {
 	deletionQueue := []datastructures.StorageRequestTimedAccepted{}
 	wg.Add(1)
 
+	// Message queue
+	storageRequestsChannel := make(chan datastructures.StorageRequestQueueMessage)
+	testRequestsChannel := make(chan datastructures.TestRequestQueueMessage)
+
 	go func() {
 		defer wg.Done()
-		peersconnect.ListenPeersRequestsTCP(port, NodeStorage, bytesAtPeers, scores, ratiosAtPeers, ratiosForPeers, bytesForPeers, &storedForPeers, config.BarteringFactorAcceptableRatio, &deletionQueue, &msgCounter)
+		peersconnect.ListenPeersRequestsTCP(port, NodeStorage, bytesAtPeers, scores, ratiosAtPeers, ratiosForPeers, bytesForPeers, &storedForPeers, config.BarteringFactorAcceptableRatio, &deletionQueue, &msgCounter, storageRequestsChannel, testRequestsChannel)
 	}()
 
 	// Wait for the goroutine to finish.

--- a/storage-testing/storage-testing.go
+++ b/storage-testing/storage-testing.go
@@ -3,7 +3,6 @@ package storagetesting
 import (
 	api_ipfs "bartering/api-ipfs"
 	datastructures "bartering/data-structures"
-	storagerequests "bartering/storage-requests"
 	"bartering/utils"
 	"context"
 	"crypto/sha256"
@@ -34,9 +33,10 @@ func PeriodicTests(fulfilledRequests *[]datastructures.FulfilledRequest, scores 
 			if !testResult {
 				// Could not confirm storage ; need to request storage from other node
 				fmt.Println("requesting storage from other node ... ")
-				stoReq := datastructures.StorageRequest{CID: fulfilledRequest.CID, FileSize: fulfilledRequest.FileSize}
-				peersToRq := storagerequests.RemovePeerFromPeers(scores, fulfilledRequest.Peer)
-				storagerequests.StoreKCopiesOnNetwork(peersToRq, 1, stoReq, port, bytesAtPeers, fulfilledRequests, scoreDecreaseRefStoReq)
+				// stoReq := datastructures.StorageRequest{CID: fulfilledRequest.CID, FileSize: fulfilledRequest.FileSize}
+				// peersToRq := storagerequests.RemovePeerFromPeers(scores, fulfilledRequest.Peer)
+				// storagerequests.StoreKCopiesOnNetwork(peersToRq, 1, stoReq, port, bytesAtPeers, fulfilledRequests, scoreDecreaseRefStoReq)
+				// Todo : review this logic. SHould jsut be send a msg to channel + slash peer score
 			}
 		}
 	}
@@ -63,17 +63,23 @@ func RequestTest(CID string, filesAtPeers []datastructures.FilesAtPeers, scores 
 
 }
 
-func HandleTest(CID string, conn net.Conn) {
+func HandleTest(testRequestsChannel chan datastructures.TestRequestQueueMessage) {
 
 	/*
 		Function to perform tests upon recieving a test request
 		Arguments : CID as a string, connection as net.Conn
 	*/
 
-	answer := computeExpectedAnswer(CID)
-	fmt.Println("Proof computed : ", answer)
-	buffer := []byte(answer)
-	conn.Write(buffer) // INCREASE NBMSG COUNTER
+	for request := range testRequestsChannel {
+		CID := request.CID
+		conn := request.Conn
+
+		answer := computeExpectedAnswer(CID)
+		fmt.Println("Proof computed : ", answer)
+		buffer := []byte(answer)
+		conn.Write(buffer) // INCREASE NBMSG COUNTER
+
+	}
 
 }
 


### PR DESCRIPTION
We now have a fixed number of threads to handle connections, handle new data on the node, handle new storage requests and handle test requests. We use channels for communication between those threads. 

For example, if a new file is detected in data, FSwatcher will detect it, pin it to IPFS and send a message on the newFileChannel. On the other hand, a dedicated thread is listening on the channel. It will get the message, and request storage from other peers. If this fails, we can have a retry mechanism by simply sending the same message on the queue again. 

Other example : we get a proof request. The listener will send a message with the needed CID on a channel.  A dedicated channel will listen on the channel, get the request and handle it. 

This way we ensure we keep a known number of routines running.